### PR TITLE
Fixes internal stack accumulating keys forever

### DIFF
--- a/SimpleQueue.js
+++ b/SimpleQueue.js
@@ -35,7 +35,7 @@ SimpleQueue.prototype.resume = function(){
 SimpleQueue.prototype._checkStack = function(){
 	while(this._stack[this._finished]){
 	    this._callback.apply(this, this._stack[this._finished]);
-	    this._stack[this._finished] = null;
+	    delete this._stack[this._finished];
 	    this._finished += 1;
 	}
 	if(this._working === 0 && this._queue.length === 0 && this._done){

--- a/tests/00-run.js
+++ b/tests/00-run.js
@@ -26,8 +26,10 @@ function run(module){
 			throw Error("undexpected output, got: " + JSON.stringify(results));
 	
 		var took = Date.now() - start;
-		if(took < module.takes) throw Error("didn't take enough time");
+		var stackSize = Object.keys(queue._stack).length;
+		if (took < module.takes) throw Error("didn't take enough time");
 		if(took > (module.takes + 500)) throw Error("wasted time");
+		if(stackSize !== 0) throw Error("stack size must be 0 at the end");
 		
 		console.log("finished", module.name, "after (ms):", took);
 	}, module.concurrent);


### PR DESCRIPTION
```
this._stack[this._finished] = null;
```
Remove the value from the memory but the key stay on the stack.
By deleting the key we release the variable and the memory
 ```
delete this._stack[this._finished];
```

Additionally I changed the test file to ensure the change works